### PR TITLE
Updates from WinUsbCDC

### DIFF
--- a/winusbpy/__init__.py
+++ b/winusbpy/__init__.py
@@ -1,6 +1,6 @@
 import os
 if os.name == 'nt':
-	from winusbpy import *
-	from winusb import *
+	from .winusbpy import *
+	from .winusb import *
 else:
 	raise ImportError("WinUsbPy only works on Windows platform")

--- a/winusbpy/examples/winusbtest.py
+++ b/winusbpy/examples/winusbtest.py
@@ -3,7 +3,8 @@ import time
 from winusbpy import *
 from ctypes import *
 from ctypes.wintypes import *
-from winusbclasses import DIGCF_DEVICE_INTERFACE, DIGCF_PRESENT, GENERIC_WRITE, GENERIC_READ, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE
+from ..winusbclasses import DIGCF_DEVICE_INTERFACE, DIGCF_PRESENT, GENERIC_WRITE, GENERIC_READ, FILE_SHARE_READ, \
+    FILE_SHARE_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE
 
 pl2303_vid = "067b"
 pl2303_pid = "2303"
@@ -35,7 +36,8 @@ pkt20 = UsbSetupPacket(0x40, 0x01, 0x0000, 0x01, 0x00)
 
 """ USB Data"""
 hello = create_string_buffer("Hello")
-header = create_string_buffer("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00")
+header = create_string_buffer(
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00")
 tx1 = create_string_buffer("\x18")
 tx2 = create_string_buffer("\x08")
 tx3 = create_string_buffer("\x08")
@@ -51,7 +53,7 @@ tx12 = create_string_buffer("\x00")
 
 api = WinUSBApi()
 byte_array = c_byte * 8
-guid = GUID(0xA5DCBF10L, 0x6530, 0x11D2, byte_array(0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED))
+guid = GUID(0xA5DCBF10, 0x6530, 0x11D2, byte_array(0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED))
 flags = DWORD(DIGCF_DEVICE_INTERFACE | DIGCF_PRESENT)
 i = 0
 member_index = DWORD(i)
@@ -69,137 +71,180 @@ Enumerate all USB Devices Searching for a PL2303 device
 """
 hdev_info = api.exec_function_setupapi("SetupDiGetClassDevs", byref(guid), None, None, flags)
 
-while api.exec_function_setupapi("SetupDiEnumDeviceInterfaces", hdev_info, None, byref(guid), member_index, byref(sp_device_interface_data)):
-	# Get the required buffer size and resize SpDeviceInterfaceDetailData
-	api.exec_function_setupapi("SetupDiGetDeviceInterfaceDetail", hdev_info, byref(sp_device_interface_data), None, 0, byref(required_size), None)
-	resize(sp_device_interface_detail_data, required_size.value)
-	
-	""" I have been stuck here for hours. cb_size must reflect the fix part of the Struct!!!!"""
-	sp_device_interface_detail_data.cb_size = sizeof(SpDeviceInterfaceDetailData) - sizeof(WCHAR * 1)
-	
-	if api.exec_function_setupapi("SetupDiGetDeviceInterfaceDetail", hdev_info, byref(sp_device_interface_data), byref(sp_device_interface_detail_data), required_size, byref(required_size), byref(sp_device_info_data)):
-		path = wstring_at(byref(sp_device_interface_detail_data, sizeof(DWORD)))
-		if is_device(pl2303_vid, pl2303_pid, path):
-			print "PL 2303 PATH: " + path
-			break
-	else:
-		error_code = api.exec_function_kernel32("GetLastError")
-		print "Error: " + str(error_code)
+while api.exec_function_setupapi("SetupDiEnumDeviceInterfaces", hdev_info, None, byref(guid), member_index,
+                                 byref(sp_device_interface_data)):
+    # Get the required buffer size and resize SpDeviceInterfaceDetailData
+    api.exec_function_setupapi("SetupDiGetDeviceInterfaceDetail", hdev_info, byref(sp_device_interface_data), None, 0,
+                               byref(required_size), None)
+    resize(sp_device_interface_detail_data, required_size.value)
 
-	i += 1
-	member_index = DWORD(i)
-	required_size = c_ulong(0)
-	resize(sp_device_interface_detail_data, sizeof(SpDeviceInterfaceDetailData))
+    """ I have been stuck here for hours. cb_size must reflect the fix part of the Struct!!!!"""
+    sp_device_interface_detail_data.cb_size = sizeof(SpDeviceInterfaceDetailData) - sizeof(WCHAR * 1)
+
+    if api.exec_function_setupapi("SetupDiGetDeviceInterfaceDetail", hdev_info, byref(sp_device_interface_data),
+                                  byref(sp_device_interface_detail_data), required_size, byref(required_size),
+                                  byref(sp_device_info_data)):
+        path = wstring_at(byref(sp_device_interface_detail_data, sizeof(DWORD)))
+        if is_device(pl2303_vid, pl2303_pid, path):
+            print("PL 2303 PATH: " + path)
+            break
+    else:
+        error_code = api.exec_function_kernel32("GetLastError")
+        print("Error: " + str(error_code))
+
+    i += 1
+    member_index = DWORD(i)
+    required_size = c_ulong(0)
+    resize(sp_device_interface_detail_data, sizeof(SpDeviceInterfaceDetailData))
 
 """Open PL2303 Device"""
-handle_file = api.exec_function_kernel32("CreateFileW", path, GENERIC_WRITE|GENERIC_READ, FILE_SHARE_WRITE|FILE_SHARE_READ, None, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL|FILE_FLAG_OVERLAPPED, None)
+handle_file = api.exec_function_kernel32("CreateFileW", path, GENERIC_WRITE | GENERIC_READ,
+                                         FILE_SHARE_WRITE | FILE_SHARE_READ, None, OPEN_EXISTING,
+                                         FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, None)
 if INVALID_HANDLE_VALUE == handle_file:
-	print "Error Creating File"
+    print("Error Creating File")
 else:
-	print "No error"
-	handle_winusb = c_void_p()
-	result = api.exec_function_winusb("WinUsb_Initialize", handle_file, byref(handle_winusb))
-	if result != 0:
-		""" Get PL2303 Speed """
-		info_type = c_ulong(1)
-		buff = (c_void_p * 1) ()
-		buff_length = c_ulong(sizeof(c_void_p))
+    print("No error")
+    handle_winusb = c_void_p()
+    result = api.exec_function_winusb("WinUsb_Initialize", handle_file, byref(handle_winusb))
+    if result != 0:
+        """ Get PL2303 Speed """
+        info_type = c_ulong(1)
+        buff = (c_void_p * 1)()
+        buff_length = c_ulong(sizeof(c_void_p))
 
-		result = api.exec_function_winusb("WinUsb_QueryDeviceInformation", handle_winusb, info_type, byref(buff_length),buff)
-		if result != 0:
-			print "Speed: " + str(buff[0])
-			
-		else:
-			error_code = api.exec_function_kernel32("GetLastError")
-			print "Error Query Device: " + str(error_code)
+        result = api.exec_function_winusb("WinUsb_QueryDeviceInformation", handle_winusb, info_type, byref(buff_length),
+                                          buff)
+        if result != 0:
+            print("Speed: " + str(buff[0]))
 
-		""" Interface Settings """
-		response = api.exec_function_winusb("WinUsb_QueryInterfaceSettings", handle_winusb ,c_ubyte(0), byref(interface_descriptor))
-		
-		if response == 0:
-			error_code = api.exec_function_kernel32("GetLastError")
-			print "Error Query Interface: " + str(error_code)
-		if response != 0:
-			print "bLength: " + str(interface_descriptor.b_length)
-			print "bDescriptorType: " + str(interface_descriptor.b_descriptor_type)
-			print "bInterfaceNumber: " + str(interface_descriptor.b_interface_number)
-			print "bAlternateSetting: " + str(interface_descriptor.b_alternate_setting)
-			print "bNumEndpoints " + str(interface_descriptor.b_num_endpoints)
-			print "bInterfaceClass " + str(interface_descriptor.b_interface_class)
-			print "bInterfaceSubClass: " + str(interface_descriptor.b_interface_sub_class)
-			print "bInterfaceProtocol: " + str(interface_descriptor.b_interface_protocol)
-			print "iInterface: " + str(interface_descriptor.i_interface)
+        else:
+            error_code = api.exec_function_kernel32("GetLastError")
+            print("Error Query Device: " + str(error_code))
 
-			""" Endpoints information """
-			i = 0
-			endpoint_index = c_ubyte(0)
-			pipe_info = PipeInfo()
-			while i <= interface_descriptor.b_num_endpoints:
-				result = api.exec_function_winusb("WinUsb_QueryPipe", handle_winusb, c_ubyte(0), endpoint_index, byref(pipe_info))
-				if result != 0:
-					print "PipeType: " + str(pipe_info.pipe_type)
-					print "PipeId: " + str(pipe_info.pipe_id)
-					print "MaximumPacketSize: " + str(pipe_info.maximum_packet_size)
-					print "Interval: " + str(pipe_info.interval)
-				i += 1
-				endpoint_index = c_ubyte(i)
+        """ Interface Settings """
+        response = api.exec_function_winusb("WinUsb_QueryInterfaceSettings", handle_winusb, c_ubyte(0),
+                                            byref(interface_descriptor))
 
-			""" Control setup """
-			buff1 = c_ubyte()
-			buff2 = (c_ubyte *2)()
-			buff_set_line = (c_ubyte * 7)(0xc0, 0x12, 0x00, 0x00, 0x00, 0x00, 0x08)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt1, byref(buff1), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt2, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt3, byref(buff1), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt4, byref(buff1), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt5, byref(buff1), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt6, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt7, byref(buff1), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt8, byref(buff1), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt9, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt10, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt11, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt12, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
+        if response == 0:
+            error_code = api.exec_function_kernel32("GetLastError")
+            print("Error Query Interface: " + str(error_code))
+        if response != 0:
+            print("bLength: " + str(interface_descriptor.b_length))
+            print("bDescriptorType: " + str(interface_descriptor.b_descriptor_type))
+            print("bInterfaceNumber: " + str(interface_descriptor.b_interface_number))
+            print("bAlternateSetting: " + str(interface_descriptor.b_alternate_setting))
+            print("bNumEndpoints " + str(interface_descriptor.b_num_endpoints))
+            print("bInterfaceClass " + str(interface_descriptor.b_interface_class))
+            print("bInterfaceSubClass: " + str(interface_descriptor.b_interface_sub_class))
+            print("bInterfaceProtocol: " + str(interface_descriptor.b_interface_protocol))
+            print("iInterface: " + str(interface_descriptor.i_interface))
 
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt13, byref(buff_set_line), c_ulong(7), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt14, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt15, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt16, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt17, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
+            """ Endpoints information """
+            i = 0
+            endpoint_index = c_ubyte(0)
+            pipe_info = PipeInfo()
+            while i <= interface_descriptor.b_num_endpoints:
+                result = api.exec_function_winusb("WinUsb_QueryPipe", handle_winusb, c_ubyte(0), endpoint_index,
+                                                  byref(pipe_info))
+                if result != 0:
+                    print("PipeType: " + str(pipe_info.pipe_type))
+                    print("PipeId: " + str(pipe_info.pipe_id))
+                    print("MaximumPacketSize: " + str(pipe_info.maximum_packet_size))
+                    print("Interval: " + str(pipe_info.interval))
+                i += 1
+                endpoint_index = c_ubyte(i)
 
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt18, byref(buff2), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt19, byref(buff2), c_ulong(1), byref(c_ulong(0)), None)
-			api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt20, byref(buff1), c_ulong(0), byref(c_ulong(0)), None)
+            """ Control setup """
+            buff1 = c_ubyte()
+            buff2 = (c_ubyte * 2)()
+            buff_set_line = (c_ubyte * 7)(0xc0, 0x12, 0x00, 0x00, 0x00, 0x00, 0x08)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt1, byref(buff1), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt2, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt3, byref(buff1), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt4, byref(buff1), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt5, byref(buff1), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt6, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt7, byref(buff1), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt8, byref(buff1), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt9, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt10, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt11, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt12, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
 
-			""" Send Data """
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), hello, c_ulong(5), byref(c_ulong(0)), None)
-			time.sleep(0.045)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), header, c_ulong(42), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx1, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx2, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx3, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx4, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx5, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx6, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx7, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx8, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx9, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx10, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx11, c_ulong(1), byref(c_ulong(0)), None)
-			time.sleep(0.380)
-			api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx12, c_ulong(1), byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt13, byref(buff_set_line), c_ulong(7),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt14, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt15, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt16, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt17, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
 
-	else:
-		error_code = api.exec_function_kernel32("GetLastError")
-		print "Error" + str(error_code)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt18, byref(buff2), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt19, byref(buff2), c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            api.exec_function_winusb("WinUsb_ControlTransfer", handle_winusb, pkt20, byref(buff1), c_ulong(0),
+                                     byref(c_ulong(0)), None)
+
+            """ Send Data """
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), hello, c_ulong(5),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.045)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), header, c_ulong(42),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx1, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx2, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx3, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx4, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx5, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx6, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx7, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx8, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx9, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx10, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx11, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+            time.sleep(0.380)
+            api.exec_function_winusb("WinUsb_WritePipe", handle_winusb, c_ubyte(0x02), tx12, c_ulong(1),
+                                     byref(c_ulong(0)), None)
+
+    else:
+        error_code = api.exec_function_kernel32("GetLastError")
+        print("Error" + str(error_code))

--- a/winusbpy/examples/winusbtest2.py
+++ b/winusbpy/examples/winusbtest2.py
@@ -1,8 +1,9 @@
 """Test2: PL2303 serial port user-space driver using WINUSB high level api"""
 import time
 from winusbpy import *
-pl2303_vid = "067b"
-pl2303_pid = "2303"
+
+pl2303_vid = "2309"
+pl2303_pid = "0606"
 
 """ USB Setup Packets """
 pkt1 = UsbSetupPacket(0xc0, 0x01, 0x8484, 0x00, 0x01)
@@ -29,107 +30,107 @@ pkt20 = UsbSetupPacket(0x40, 0x01, 0x0000, 0x01, 0x00)
 
 """ USB Data """
 hello = "Hello"
-header = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00"
-tx1 = "\x18"
-tx2 = "\x08"
-tx3 = "\x08"
-tx4 = "\x14"
-tx5 = "\x14"
-tx6 = "\x22"
-tx7 = "\x3e"
-tx8 = "\x22"
-tx9 = "\x77"
-tx10 = "\x00"
-tx11 = "\x00"
-tx12 = "\x00"
+header = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x01\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00\x08\x01\x00\x00"
+tx1 = b"\x18"
+tx2 = b"\x08"
+tx3 = b"\x08"
+tx4 = b"\x14"
+tx5 = b"\x14"
+tx6 = b"\x22"
+tx7 = b"\x3e"
+tx8 = b"\x22"
+tx9 = b"\x77"
+tx10 = b"\x00"
+tx11 = b"\x00"
+tx12 = b"\x00"
 
 """ WinUsbPy  """
 
 api = WinUsbPy()
 result = api.list_usb_devices(deviceinterface=True, present=True)
 if result > 0:
-	if api.init_winusb_device(pl2303_vid, pl2303_pid):
-		speed = api.query_device_info(query=1)
-		if speed != -1:
-			print "Device Speed: " + str(speed)
-		else:
-			print "Device speed could not be obtained"
+    if api.init_winusb_device(pl2303_vid, pl2303_pid):
+        speed = api.query_device_info(query=1)
+        if speed != -1:
+            print("Device Speed: " + str(speed))
+        else:
+            print("Device speed could not be obtained")
 
-		interface_descriptor = api.query_interface_settings(0)
+        interface_descriptor = api.query_interface_settings(0)
 
-		if interface_descriptor != None:
-			print "bLength: " + str(interface_descriptor.b_length)
-			print "bDescriptorType: " + str(interface_descriptor.b_descriptor_type)
-			print "bInterfaceNumber: " + str(interface_descriptor.b_interface_number)
-			print "bAlternateSetting: " + str(interface_descriptor.b_alternate_setting)
-			print "bNumEndpoints " + str(interface_descriptor.b_num_endpoints)
-			print "bInterfaceClass " + str(interface_descriptor.b_interface_class)
-			print "bInterfaceSubClass: " + str(interface_descriptor.b_interface_sub_class)
-			print "bInterfaceProtocol: " + str(interface_descriptor.b_interface_protocol)
-			print "iInterface: " + str(interface_descriptor.i_interface)
+        if interface_descriptor != None:
+            print("bLength: " + str(interface_descriptor.b_length))
+            print("bDescriptorType: " + str(interface_descriptor.b_descriptor_type))
+            print("bInterfaceNumber: " + str(interface_descriptor.b_interface_number))
+            print("bAlternateSetting: " + str(interface_descriptor.b_alternate_setting))
+            print("bNumEndpoints " + str(interface_descriptor.b_num_endpoints))
+            print("bInterfaceClass " + str(interface_descriptor.b_interface_class))
+            print("bInterfaceSubClass: " + str(interface_descriptor.b_interface_sub_class))
+            print("bInterfaceProtocol: " + str(interface_descriptor.b_interface_protocol))
+            print("iInterface: " + str(interface_descriptor.i_interface))
 
-		pipe_info_list = map(api.query_pipe, range(interface_descriptor.b_num_endpoints))
-		for item in pipe_info_list:
-				print "PipeType: " + str(item.pipe_type)
-				print "PipeId: " + str(item.pipe_id)
-				print "MaximumPacketSize: " + str(item.maximum_packet_size)
-				print "Interval: " + str(item.interval)
+        pipe_info_list = map(api.query_pipe, range(interface_descriptor.b_num_endpoints))
+        for item in pipe_info_list:
+            print("PipeType: " + str(item.pipe_type))
+            print("PipeId: " + str(item.pipe_id))
+            print("MaximumPacketSize: " + str(item.maximum_packet_size))
+            print("Interval: " + str(item.interval))
 
-		"""
-		buff = None -> Buffer length will be zero. No data expected
-		"""
-		api.control_transfer(pkt1, buff=[0])
-		api.control_transfer(pkt2, buff=None)
-		api.control_transfer(pkt3, buff=[0])
-		api.control_transfer(pkt4, buff=[0])
-		api.control_transfer(pkt5, buff=[0])
-		api.control_transfer(pkt6, buff=None)
-		api.control_transfer(pkt7, buff=[0])
-		api.control_transfer(pkt8, buff=[0])
-		api.control_transfer(pkt9, buff=None)
-		api.control_transfer(pkt10, buff=None)
-		api.control_transfer(pkt11, buff=None)
-		api.control_transfer(pkt12, buff=None)
-		api.control_transfer(pkt13, buff=[0xc0, 0x12, 0x00, 0x00, 0x00, 0x00, 0x08])
-		api.control_transfer(pkt14, buff=None)
-		api.control_transfer(pkt15, buff=None)
-		api.control_transfer(pkt16, buff=None)
-		api.control_transfer(pkt17, buff=None)
-		api.control_transfer(pkt18, buff=[0,0])
-		api.control_transfer(pkt19, buff=[0,0])
-		api.control_transfer(pkt20, buff=None)
+        """
+        buff = None -> Buffer length will be zero. No data expected
+        """
+        api.control_transfer(pkt1, buff=[0])
+        api.control_transfer(pkt2, buff=None)
+        api.control_transfer(pkt3, buff=[0])
+        api.control_transfer(pkt4, buff=[0])
+        api.control_transfer(pkt5, buff=[0])
+        api.control_transfer(pkt6, buff=None)
+        api.control_transfer(pkt7, buff=[0])
+        api.control_transfer(pkt8, buff=[0])
+        api.control_transfer(pkt9, buff=None)
+        api.control_transfer(pkt10, buff=None)
+        api.control_transfer(pkt11, buff=None)
+        api.control_transfer(pkt12, buff=None)
+        api.control_transfer(pkt13, buff=[0xc0, 0x12, 0x00, 0x00, 0x00, 0x00, 0x08])
+        api.control_transfer(pkt14, buff=None)
+        api.control_transfer(pkt15, buff=None)
+        api.control_transfer(pkt16, buff=None)
+        api.control_transfer(pkt17, buff=None)
+        api.control_transfer(pkt18, buff=[0, 0])
+        api.control_transfer(pkt19, buff=[0, 0])
+        api.control_transfer(pkt20, buff=None)
 
-		api.write(0x02, hello)
-		time.sleep(0.045)
-		api.write(0x02, header)
-		time.sleep(0.380)
-		api.write(0x02, tx1)
-		time.sleep(0.380)
-		api.write(0x02, tx2)
-		time.sleep(0.380)
-		api.write(0x02, tx3)
-		time.sleep(0.380)
-		api.write(0x02, tx4)
-		time.sleep(0.380)
-		api.write(0x02, tx5)
-		time.sleep(0.380)
-		api.write(0x02, tx6)
-		time.sleep(0.380)
-		api.write(0x02, tx7)
-		time.sleep(0.380)
-		api.write(0x02, tx8)
-		time.sleep(0.380)
-		api.write(0x02, tx9)
-		time.sleep(0.380)
-		api.write(0x02, tx10)
-		time.sleep(0.380)
-		api.write(0x02, tx11)
-		time.sleep(0.380)
-		api.write(0x02, tx12)
+        api.write(0x02, hello)
+        time.sleep(0.045)
+        api.write(0x02, header)
+        time.sleep(0.380)
+        api.write(0x02, tx1)
+        time.sleep(0.380)
+        api.write(0x02, tx2)
+        time.sleep(0.380)
+        api.write(0x02, tx3)
+        time.sleep(0.380)
+        api.write(0x02, tx4)
+        time.sleep(0.380)
+        api.write(0x02, tx5)
+        time.sleep(0.380)
+        api.write(0x02, tx6)
+        time.sleep(0.380)
+        api.write(0x02, tx7)
+        time.sleep(0.380)
+        api.write(0x02, tx8)
+        time.sleep(0.380)
+        api.write(0x02, tx9)
+        time.sleep(0.380)
+        api.write(0x02, tx10)
+        time.sleep(0.380)
+        api.write(0x02, tx11)
+        time.sleep(0.380)
+        api.write(0x02, tx12)
 
 
-	else:
-		print "PL2303 could not be init"
+    else:
+        print("PL2303 could not be init")
 
 else:
-	print "No Usb devices connected"
+    print("No Usb devices connected")

--- a/winusbpy/winusb.py
+++ b/winusbpy/winusb.py
@@ -1,50 +1,51 @@
-from winusberror import WinUSBError
-from winusbutils import *
+from .winusberror import WinUSBError
+from .winusbutils import *
+
 
 class WinUSBApi(object):
-	""" Facade class wrapping USB library WinUSB"""
+    """ Facade class wrapping USB library WinUSB"""
 
-	def __init__(self):
+    def __init__(self):
 
-		try:
-			self._kernel32 = windll.kernel32
-		except WindowsError:
-			raise WinUSBError("Kernel32 dll is not present. Are you really using Windows?")
+        try:
+            self._kernel32 = windll.kernel32
+        except WindowsError:
+            raise WinUSBError("Kernel32 dll is not present. Are you really using Windows?")
 
-		try:
-			self._winusb = windll.winusb
-		except WindowsError:
-			raise WinUSBError("WinUsb dll is not present")
+        try:
+            self._winusb = windll.winusb
+        except WindowsError:
+            raise WinUSBError("WinUsb dll is not present")
 
-		try:
-			self._setupapi = windll.SetupApi
-		except WindowsError:
-			raise WinUSBError("SetupApi dll is not present")
+        try:
+            self._setupapi = windll.SetupApi
+        except WindowsError:
+            raise WinUSBError("SetupApi dll is not present")
 
-		self._winusb_functions_dict = get_winusb_functions(self._winusb)
-		self._kernel32_functions_dict = get_kernel32_functions(self._kernel32)
-		self._setupapi_functions_dict = get_setupapi_functions(self._setupapi)
+        self._winusb_functions_dict = get_winusb_functions(self._winusb)
+        self._kernel32_functions_dict = get_kernel32_functions(self._kernel32)
+        self._setupapi_functions_dict = get_setupapi_functions(self._setupapi)
 
+    def exec_function_winusb(self, function_name, *args):
+        function_caller = self._configure_ctype_function(self._winusb_functions_dict, function_name)
+        return function_caller(args)
 
-	def exec_function_winusb(self, function_name, *args):
-		function_caller = self._configure_ctype_function(self._winusb_functions_dict, function_name)
-		return function_caller(args)
+    def exec_function_kernel32(self, function_name, *args):
+        function_caller = self._configure_ctype_function(self._kernel32_functions_dict, function_name)
+        return function_caller(args)
 
-	def exec_function_kernel32(self, function_name, *args):
-		function_caller = self._configure_ctype_function(self._kernel32_functions_dict, function_name)
-		return function_caller(args)
+    def exec_function_setupapi(self, function_name, *args):
+        function_caller = self._configure_ctype_function(self._setupapi_functions_dict, function_name)
+        return function_caller(args)
 
-	def exec_function_setupapi(self, function_name, *args):
-		function_caller = self._configure_ctype_function(self._setupapi_functions_dict, function_name)
-		return function_caller(args)
+    def _configure_ctype_function(self, dll_dict_functions, function_name):
+        def _function_caller(*args):
+            function = dll_dict_functions["functions"][function_name]
+            try:
+                function.restype = dll_dict_functions["restypes"][function_name]
+                function.argtypes = dll_dict_functions["argtypes"][function_name]
+            except KeyError:
+                pass
+            return function(*args[0])
 
-	def _configure_ctype_function(self, dll_dict_functions, function_name):
-		def _function_caller(*args):
-			function = dll_dict_functions["functions"][function_name]
-			try:
-				function.restype = dll_dict_functions["restypes"][function_name]
-				function.argtypes = dll_dict_functions["argtypes"][function_name]
-			except KeyError:
-				pass
-			return function(*args[0])
-		return _function_caller
+        return _function_caller

--- a/winusbpy/winusbclasses.py
+++ b/winusbpy/winusbclasses.py
@@ -9,7 +9,7 @@ DIGCF_PROFILE = 0x00000008
 DIGCF_DEVICE_INTERFACE = 0x00000010
 
 """Flags controlling File acccess"""
-GENERIC_WRITE = (1073741824) 
+GENERIC_WRITE = (1073741824)
 GENERIC_READ = (-2147483648)
 FILE_SHARE_READ = 1
 FILE_SHARE_WRITE = 2
@@ -31,9 +31,10 @@ PIPE_TYPE_INTERRUPT = 3
 ERROR_IO_INCOMPLETE = 996
 ERROR_IO_PENDING = 997
 
+
 class UsbSetupPacket(Structure):
-	_fields_ = [("request_type", c_ubyte), ("request", c_ubyte),
-				("value", c_ushort), ("index", c_ushort), ("length", c_ushort)]
+    _fields_ = [("request_type", c_ubyte), ("request", c_ubyte),
+                ("value", c_ushort), ("index", c_ushort), ("length", c_ushort)]
 
 
 class Overlapped(Structure):
@@ -46,38 +47,37 @@ class Overlapped(Structure):
 
 
 class UsbInterfaceDescriptor(Structure):
-	_fields_ = [("b_length", c_ubyte), ("b_descriptor_type", c_ubyte),
-				("b_interface_number", c_ubyte), ("b_alternate_setting", c_ubyte),
-				("b_num_endpoints", c_ubyte), ("b_interface_class", c_ubyte),
-				("b_interface_sub_class", c_ubyte), ("b_interface_protocol", c_ubyte),
-				("i_interface", c_ubyte)]
+    _fields_ = [("b_length", c_ubyte), ("b_descriptor_type", c_ubyte),
+                ("b_interface_number", c_ubyte), ("b_alternate_setting", c_ubyte),
+                ("b_num_endpoints", c_ubyte), ("b_interface_class", c_ubyte),
+                ("b_interface_sub_class", c_ubyte), ("b_interface_protocol", c_ubyte),
+                ("i_interface", c_ubyte)]
 
 
 class PipeInfo(Structure):
-	_fields_ = [("pipe_type", c_ulong,), ("pipe_id", c_ubyte),
-				("maximum_packet_size", c_ushort), ("interval", c_ubyte)]
+    _fields_ = [("pipe_type", c_ulong,), ("pipe_id", c_ubyte),
+                ("maximum_packet_size", c_ushort), ("interval", c_ubyte)]
 
 
 class LpSecurityAttributes(Structure):
-	_fields_ = [("n_length", DWORD), ("lp_security_descriptor", c_void_p), 
-			 	("b_Inherit_handle",BOOL)]
+    _fields_ = [("n_length", DWORD), ("lp_security_descriptor", c_void_p),
+                ("b_Inherit_handle", BOOL)]
 
 
 class GUID(Structure):
-	_fields_ = [("data1", DWORD), ("data2", WORD),
-				("data3", WORD), ("data4", c_byte * 8)]
+    _fields_ = [("data1", DWORD), ("data2", WORD),
+                ("data3", WORD), ("data4", c_byte * 8)]
 
 
 class SpDevinfoData(Structure):
-	_fields_ = [("cb_size", DWORD), ("class_guid", GUID),
-				("dev_inst", DWORD), ("reserved", POINTER(c_ulong))]
+    _fields_ = [("cb_size", DWORD), ("class_guid", GUID),
+                ("dev_inst", DWORD), ("reserved", POINTER(c_ulong))]
 
 
 class SpDeviceInterfaceData(Structure):
-	_fields_ = [("cb_size", DWORD), ("interface_class_guid", GUID),
-				("flags", DWORD), ("reserved", POINTER(c_ulong))]
+    _fields_ = [("cb_size", DWORD), ("interface_class_guid", GUID),
+                ("flags", DWORD), ("reserved", POINTER(c_ulong))]
 
 
 class SpDeviceInterfaceDetailData(Structure):
-	_fields_ = [("cb_size", DWORD), ("device_path",WCHAR * 1)] #devicePath array!!!
-
+    _fields_ = [("cb_size", DWORD), ("device_path", WCHAR * 1)]  # devicePath array!!!

--- a/winusbpy/winusberror.py
+++ b/winusbpy/winusberror.py
@@ -1,10 +1,9 @@
-
 class WinUSBError(Exception):
 
-	def __init__(self, reason, response=None):
-		self.reason = reason
-		self.response = response
-		Exception.__init__(self, reason)
+    def __init__(self, reason, response=None):
+        self.reason = reason
+        self.response = response
+        Exception.__init__(self, reason)
 
-	def __str__(self):
-		return self.reason
+    def __str__(self):
+        return self.reason

--- a/winusbpy/winusbpy.py
+++ b/winusbpy/winusbpy.py
@@ -1,209 +1,216 @@
-from winusb import WinUSBApi
-from winusbclasses import GUID, DIGCF_ALLCLASSES, DIGCF_DEFAULT, DIGCF_PRESENT, DIGCF_PROFILE, DIGCF_DEVICE_INTERFACE, SpDeviceInterfaceData,  SpDeviceInterfaceDetailData, SpDevinfoData, GENERIC_WRITE, GENERIC_READ, FILE_SHARE_WRITE, FILE_SHARE_READ, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, UsbInterfaceDescriptor, PipeInfo, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, Overlapped
+from .winusb import WinUSBApi
+from .winusbclasses import GUID, DIGCF_ALLCLASSES, DIGCF_DEFAULT, DIGCF_PRESENT, DIGCF_PROFILE, DIGCF_DEVICE_INTERFACE, \
+    SpDeviceInterfaceData,  SpDeviceInterfaceDetailData, SpDevinfoData, GENERIC_WRITE, GENERIC_READ, FILE_SHARE_WRITE, \
+    FILE_SHARE_READ, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED, INVALID_HANDLE_VALUE, \
+    UsbInterfaceDescriptor, PipeInfo, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, Overlapped
 from ctypes import c_byte, byref, sizeof, c_ulong, resize, wstring_at, c_void_p, c_ubyte, create_string_buffer
 from ctypes.wintypes import DWORD, WCHAR
-from winusbutils import SetupDiGetClassDevs, SetupDiEnumDeviceInterfaces, SetupDiGetDeviceInterfaceDetail, is_device, CreateFile, WinUsb_Initialize, Close_Handle, WinUsb_Free, GetLastError, WinUsb_QueryDeviceInformation, WinUsb_GetAssociatedInterface, WinUsb_QueryInterfaceSettings, WinUsb_QueryPipe, WinUsb_ControlTransfer, WinUsb_WritePipe, WinUsb_ReadPipe, WinUsb_GetOverlappedResult
+from .winusbutils import SetupDiGetClassDevs, SetupDiEnumDeviceInterfaces, SetupDiGetDeviceInterfaceDetail, is_device, \
+    CreateFile, WinUsb_Initialize, Close_Handle, WinUsb_Free, GetLastError, WinUsb_QueryDeviceInformation, \
+    WinUsb_GetAssociatedInterface, WinUsb_QueryInterfaceSettings, WinUsb_QueryPipe, WinUsb_ControlTransfer, \
+    WinUsb_WritePipe, WinUsb_ReadPipe, WinUsb_GetOverlappedResult
+
 
 class WinUsbPy(object):
 
-	def __init__(self):
-		self.api = WinUSBApi()
-		byte_array = c_byte * 8
-		self.guid = GUID(0xA5DCBF10L, 0x6530, 0x11D2, byte_array(0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED))
-		self.handle_file = INVALID_HANDLE_VALUE
-		self.handle_winusb = c_void_p()
-		self._index = -1
+    def __init__(self):
+        self.api = WinUSBApi()
+        byte_array = c_byte * 8
+        self.guid = GUID(0xA5DCBF10, 0x6530, 0x11D2, byte_array(0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED))
+        self.handle_file = INVALID_HANDLE_VALUE
+        self.handle_winusb = c_void_p()
+        self._index = -1
 
+    def list_usb_devices(self, **kwargs):
+        self.device_paths = []
+        value = 0x00000000
+        try:
+            if kwargs.get("default"):
+                value |= DIGCF_DEFAULT
+            if kwargs.get("present"):
+                value |= DIGCF_PRESENT
+            if kwargs.get("allclasses"):
+                value |= DIGCF_ALLCLASSES
+            if kwargs.get("profile"):
+                value |= DIGCF_PROFILE
+            if kwargs.get("deviceinterface"):
+                value |= DIGCF_DEVICE_INTERFACE
+        except KeyError:
+            if value == 0x00000000:
+                value = 0x00000010
+            pass
 
-	def list_usb_devices(self, **kwargs):
-		self.device_paths = []
-		value = 0x00000000
-		try:
-			if kwargs["default"] == True:
-				value |= DIGCF_DEFAULT
-			if kwargs["present"] == True:
-				value |= DIGCF_PRESENT
-			if kwargs["allclasses"] == True:
-				value |= DIGCF_ALLCLASSES
-			if kwargs["profile"] == True:
-				value |= DIGCF_PROFILE
-			if kwargs["deviceinterface"] == True:
-				value |= DIGCF_DEVICE_INTERFACE
-		except KeyError:
-			if value == 0x00000000:
-				value = 0x00000010
-			pass
+        flags = DWORD(value)
+        self.handle = self.api.exec_function_setupapi(SetupDiGetClassDevs, byref(self.guid), None, None, flags)
 
-		flags = DWORD(value)
-		self.handle = self.api.exec_function_setupapi(SetupDiGetClassDevs, byref(self.guid), None, None, flags)
+        sp_device_interface_data = SpDeviceInterfaceData()
+        sp_device_interface_data.cb_size = sizeof(sp_device_interface_data)
+        sp_device_interface_detail_data = SpDeviceInterfaceDetailData()
+        sp_device_info_data = SpDevinfoData()
+        sp_device_info_data.cb_size = sizeof(sp_device_info_data)
+        i = 0
+        required_size = c_ulong(0)
+        member_index = DWORD(i)
 
-		sp_device_interface_data = SpDeviceInterfaceData()
-		sp_device_interface_data.cb_size = sizeof(sp_device_interface_data)
-		sp_device_interface_detail_data = SpDeviceInterfaceDetailData()
-		sp_device_info_data = SpDevinfoData()
-		sp_device_info_data.cb_size = sizeof(sp_device_info_data)
-		i = 0
-		required_size = c_ulong(0)
-		member_index = DWORD(i)
+        while self.api.exec_function_setupapi(SetupDiEnumDeviceInterfaces, self.handle, None, byref(self.guid),
+                                              member_index, byref(sp_device_interface_data)):
+            self.api.exec_function_setupapi(SetupDiGetDeviceInterfaceDetail, self.handle,
+                                            byref(sp_device_interface_data), None, 0, byref(required_size), None)
+            resize(sp_device_interface_detail_data, required_size.value)
+            sp_device_interface_detail_data.cb_size = sizeof(SpDeviceInterfaceDetailData) - sizeof(WCHAR * 1)
+            if self.api.exec_function_setupapi(SetupDiGetDeviceInterfaceDetail, self.handle,
+                                               byref(sp_device_interface_data), byref(sp_device_interface_detail_data),
+                                               required_size, byref(required_size), byref(sp_device_info_data)):
+                path = wstring_at(byref(sp_device_interface_detail_data, sizeof(DWORD)))
+                self.device_paths.append(path)
+            i += 1
+            member_index = DWORD(i)
+            required_size = c_ulong(0)
+            resize(sp_device_interface_detail_data, sizeof(SpDeviceInterfaceDetailData))
+        return len(self.device_paths) > 0
 
-		while self.api.exec_function_setupapi(SetupDiEnumDeviceInterfaces , self.handle, None, byref(self.guid), member_index, byref(sp_device_interface_data)):
-			self.api.exec_function_setupapi(SetupDiGetDeviceInterfaceDetail, self.handle, byref(sp_device_interface_data), None, 0, byref(required_size), None)
-			resize(sp_device_interface_detail_data, required_size.value)
-			sp_device_interface_detail_data.cb_size = sizeof(SpDeviceInterfaceDetailData) - sizeof(WCHAR * 1)
-			if self.api.exec_function_setupapi(SetupDiGetDeviceInterfaceDetail, self.handle, byref(sp_device_interface_data), byref(sp_device_interface_detail_data), required_size, byref(required_size), byref(sp_device_info_data)):
-				path = wstring_at(byref(sp_device_interface_detail_data, sizeof(DWORD)))
-				self.device_paths.append(path)
-			i += 1
-			member_index = DWORD(i)
-			required_size = c_ulong(0)
-			resize(sp_device_interface_detail_data, sizeof(SpDeviceInterfaceDetailData))
-		return len(self.device_paths) > 0
-	
+    def find_device(self, path):
+        return is_device(self._vid, self._pid, path)
 
-	def find_device(self, path): 
-		return is_device(self._vid, self._pid, path)
-		
+    def init_winusb_device(self, vid, pid):
+        self._vid = vid
+        self._pid = pid
+        try:
+            ftr = filter(self.find_device, self.device_paths)
+            paths = [p for p in ftr]
+            path = paths[0]
+        except IndexError:
+            return False
 
+        self.handle_file = self.api.exec_function_kernel32(CreateFile, path, GENERIC_WRITE | GENERIC_READ,
+                                                           FILE_SHARE_WRITE | FILE_SHARE_READ, None, OPEN_EXISTING,
+                                                           FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, None)
 
-	def init_winusb_device(self, vid, pid): 
-		self._vid = vid
-		self._pid = pid
-		try:
-			path = filter(self.find_device, self.device_paths)[0]
-		except IndexError:
-			return False
+        if self.handle_file == INVALID_HANDLE_VALUE:
+            return False
+        result = self.api.exec_function_winusb(WinUsb_Initialize, self.handle_file, byref(self.handle_winusb))
+        if result == 0:
+            return False
+        else:
+            self._index = 0
+            return True
 
-		self.handle_file = self.api.exec_function_kernel32(CreateFile, path, GENERIC_WRITE|GENERIC_READ, FILE_SHARE_WRITE|FILE_SHARE_READ, None, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL|FILE_FLAG_OVERLAPPED, None)
+    def close_winusb_device(self):
+        result_file = self.api.exec_function_kernel32(Close_Handle, self.handle_file)
+        result_winusb = self.api.exec_function_winusb(WinUsb_Free, self.handle_winusb)
+        return result_file != 0 and result_winusb != 0
 
-		if self.handle_file == INVALID_HANDLE_VALUE:
-			return False
-		result = self.api.exec_function_winusb(WinUsb_Initialize, self.handle_file, byref(self.handle_winusb))
-		if result == 0:
-			return False
-		else:
-			self._index = 0
-			return True		
-		
+    def get_last_error_code(self):
+        return self.api.exec_function_kernel32(GetLastError)
 
+    def query_device_info(self, query=1):
+        info_type = c_ulong(query)
+        buff = (c_void_p * 1)()
+        buff_length = c_ulong(sizeof(c_void_p))
+        result = self.api.exec_function_winusb(WinUsb_QueryDeviceInformation, self.handle_winusb, info_type,
+                                               byref(buff_length), buff)
+        if result != 0:
+            return buff[0]
+        else:
+            return -1
 
-	def close_winusb_device(self):
-		result_file = self.api.exec_function_kernel32(Close_Handle, self.handle_file)
-		result_winusb = self.api.exec_function_winusb(WinUsb_Free, self.handle_winusb)
-		return result_file != 0 and result_winusb != 0
-
-
-	def get_last_error_code(self):
-		return self.api.exec_function_kernel32(GetLastError)
-
-
-	def query_device_info(self, query=1):
-		info_type = c_ulong(query)
-		buff = (c_void_p * 1) ()
-		buff_length = c_ulong(sizeof(c_void_p))
-		result = self.api.exec_function_winusb(WinUsb_QueryDeviceInformation, self.handle_winusb, info_type, byref(buff_length),buff)
-		if result != 0:
-			return buff[0]
-		else:
-			return -1
-
-
-	def query_interface_settings(self, index):
-		if self._index != -1:
-			temp_handle_winusb = self.handle_winusb
-			if self._index != 0:
-				result = self.api.exec_function_winusb(WinUsb_GetAssociatedInterface, self.handle_winusb, c_ubyte(index), byref(temp_handle_winusb))
-				if result == 0:
-					return False
-			interface_descriptor = UsbInterfaceDescriptor()
-			result = self.api.exec_function_winusb(WinUsb_QueryInterfaceSettings, temp_handle_winusb ,c_ubyte(0), byref(interface_descriptor))
-			if result != 0:
-				return interface_descriptor
-			else:
-				return None
-		else:
-			return None
-
-
-	def change_interface(self, index):
-		result = self.api.exec_function_winusb(WinUsb_GetAssociatedInterface, self.handle_winusb, c_ubyte(index), byref(self.handle_winusb))
-		if result != 0:
-			self._index = index
-			return True
-		else:
-			return False
-
-
-	def query_pipe(self, pipe_index):
-		pipe_info = PipeInfo()
-		result = self.api.exec_function_winusb(WinUsb_QueryPipe, self.handle_winusb, c_ubyte(0), pipe_index, byref(pipe_info))
-		if result != 0:
-			return pipe_info
-		else:
-			return None
-
-
-	def control_transfer(self, setup_packet, buff=None):
-		if buff != None:
-			if setup_packet.length > 0: # Host 2 Device 
-				buff = (c_ubyte * setup_packet.length) (* buff)
-				buffer_length = setup_packet.length
-			else: # Device 2 Host
-				buff = (c_ubyte * setup_packet.length) ()
-				buffer_length = setup_packet.length
-		else:
-			buff = c_ubyte()
-			buffer_length  = 0
-		
-		result = self.api.exec_function_winusb(WinUsb_ControlTransfer, self.handle_winusb, setup_packet, byref(buff), c_ulong(buffer_length), byref(c_ulong(0)), None)
-		return {"result":result != 0, "buffer":[buff]}
-
-
-	def write(self, pipe_id, write_buffer):
-		write_buffer = create_string_buffer(write_buffer)
-		return self.api.exec_function_winusb(WinUsb_WritePipe, self.handle_winusb, c_ubyte(pipe_id), write_buffer, c_ulong(len(write_buffer) - 1), byref(c_ulong(0)), None)
-
-
-	def read(self, pipe_id, length_buffer):
-		read_buffer = create_string_buffer(length_buffer)
-		result = self.api.exec_function_winusb(WinUsb_ReadPipe, self.handle_winusb, c_ubyte(pipe_id), read_buffer, c_ulong(length_buffer), byref(c_ulong(0)), None)
-		if result != 0:
-			return read_buffer
-		else:
-			return None
-
-                
-
-        def _overlapped_read_do(self,pipe_id):
-                self.olread_ol.Internal = 0
-                self.olread_ol.InternalHigh = 0
-                self.olread_ol.Offset = 0
-                self.olread_ol.OffsetHigh = 0
-                self.olread_ol.Pointer = 0
-                self.olread_ol.hEvent = 0                
-		result = self.api.exec_function_winusb(WinUsb_ReadPipe, self.handle_winusb, c_ubyte(pipe_id), self.olread_buf, c_ulong(self.olread_buflen), byref(c_ulong(0)), byref(self.olread_ol))
-		if result != 0:
-			return True
-		else:
-			return False
-                
-	def overlapped_read_init(self, pipe_id, length_buffer):
-                self.olread_ol = Overlapped()
-                self.olread_buf = create_string_buffer(length_buffer);
-                self.olread_buflen = length_buffer
-                return self._overlapped_read_do(pipe_id)
-
-	def overlapped_read(self, pipe_id):
-                """ keep on reading overlapped, return bytearray, empty if nothing to read, None if err"""
-                rl = c_ulong(0)
-		result = self.api.exec_function_winusb(WinUsb_GetOverlappedResult, self.handle_winusb, byref(self.olread_ol),byref(rl),False)
+    def query_interface_settings(self, index):
+        if self._index != -1:
+            temp_handle_winusb = self.handle_winusb
+            if self._index != 0:
+                result = self.api.exec_function_winusb(WinUsb_GetAssociatedInterface, self.handle_winusb,
+                                                       c_ubyte(index), byref(temp_handle_winusb))
                 if result == 0:
-                        if self.get_last_error_code() == ERROR_IO_PENDING or \
-                           self.get_last_error_code() == ERROR_IO_INCOMPLETE:
-                                return ""
-                        else:
-                                return None
-                else:
-                        ret = str(self.olread_buf[0:rl.value])
-                        self._overlapped_read_do(pipe_id)
-                        return ret
+                    return False
+            interface_descriptor = UsbInterfaceDescriptor()
+            result = self.api.exec_function_winusb(WinUsb_QueryInterfaceSettings, temp_handle_winusb, c_ubyte(0),
+                                                   byref(interface_descriptor))
+            if result != 0:
+                return interface_descriptor
+            else:
+                return None
+        else:
+            return None
 
+    def change_interface(self, index):
+        result = self.api.exec_function_winusb(WinUsb_GetAssociatedInterface, self.handle_winusb, c_ubyte(index),
+                                               byref(self.handle_winusb))
+        if result != 0:
+            self._index = index
+            return True
+        else:
+            return False
+
+    def query_pipe(self, pipe_index):
+        pipe_info = PipeInfo()
+        result = self.api.exec_function_winusb(WinUsb_QueryPipe, self.handle_winusb, c_ubyte(0), pipe_index,
+                                               byref(pipe_info))
+        if result != 0:
+            return pipe_info
+        else:
+            return None
+
+    def control_transfer(self, setup_packet, buff=None):
+        if buff != None:
+            if setup_packet.length > 0:  # Host 2 Device
+                buff = (c_ubyte * setup_packet.length)(*buff)
+                buffer_length = setup_packet.length
+            else:  # Device 2 Host
+                buff = (c_ubyte * setup_packet.length)()
+                buffer_length = setup_packet.length
+        else:
+            buff = c_ubyte()
+            buffer_length = 0
+
+        result = self.api.exec_function_winusb(WinUsb_ControlTransfer, self.handle_winusb, setup_packet, byref(buff),
+                                               c_ulong(buffer_length), byref(c_ulong(0)), None)
+        return {"result": result != 0, "buffer": [buff]}
+
+    def write(self, pipe_id, write_buffer):
+        write_buffer = create_string_buffer(write_buffer)
+        return self.api.exec_function_winusb(WinUsb_WritePipe, self.handle_winusb, c_ubyte(pipe_id), write_buffer,
+                                             c_ulong(len(write_buffer) - 1), byref(c_ulong(0)), None)
+
+    def read(self, pipe_id, length_buffer):
+        read_buffer = create_string_buffer(length_buffer)
+        result = self.api.exec_function_winusb(WinUsb_ReadPipe, self.handle_winusb, c_ubyte(pipe_id), read_buffer,
+                                               c_ulong(length_buffer), byref(c_ulong(0)), None)
+        if result != 0:
+            return read_buffer
+        else:
+            return None
+
+    def _overlapped_read_do(self,pipe_id):
+        self.olread_ol.Internal = 0
+        self.olread_ol.InternalHigh = 0
+        self.olread_ol.Offset = 0
+        self.olread_ol.OffsetHigh = 0
+        self.olread_ol.Pointer = 0
+        self.olread_ol.hEvent = 0                
+        result = self.api.exec_function_winusb(WinUsb_ReadPipe, self.handle_winusb, c_ubyte(pipe_id), self.olread_buf, 
+                                               c_ulong(self.olread_buflen), byref(c_ulong(0)), byref(self.olread_ol))
+        if result != 0:
+            return True
+        else:
+            return False
+                
+    def overlapped_read_init(self, pipe_id, length_buffer):
+        self.olread_ol = Overlapped()
+        self.olread_buf = create_string_buffer(length_buffer);
+        self.olread_buflen = length_buffer
+        return self._overlapped_read_do(pipe_id)
+
+    def overlapped_read(self, pipe_id):
+        """ keep on reading overlapped, return bytearray, empty if nothing to read, None if err"""
+        rl = c_ulong(0)
+        result = self.api.exec_function_winusb(WinUsb_GetOverlappedResult, self.handle_winusb, byref(self.olread_ol),byref(rl),False)
+        if result == 0:
+            if self.get_last_error_code() == ERROR_IO_PENDING or \
+               self.get_last_error_code() == ERROR_IO_INCOMPLETE:
+                return ""
+            else:
+                return None
+        else:
+            ret = str(self.olread_buf[0:rl.value])
+            self._overlapped_read_do(pipe_id)
+            return ret

--- a/winusbpy/winusbpy.py
+++ b/winusbpy/winusbpy.py
@@ -96,8 +96,7 @@ class WinUsbPy(object):
 
                 name = buff_friendly_name.value
             else:
-                err = self.get_last_error_code()
-                print(err)
+                print(ctypes.WinError()
             self.device_paths[name] = path
             i += 1
             member_index = DWORD(i)
@@ -207,8 +206,10 @@ class WinUsbPy(object):
 
     def write(self, pipe_id, write_buffer):
         write_buffer = create_string_buffer(write_buffer)
-        return self.api.exec_function_winusb(WinUsb_WritePipe, self.handle_winusb, c_ubyte(pipe_id), write_buffer,
-                                             c_ulong(len(write_buffer) - 1), byref(c_ulong(0)), None)
+        written = c_ulong(0)
+        self.api.exec_function_winusb(WinUsb_WritePipe, self.handle_winusb[self._index], c_ubyte(pipe_id), write_buffer,
+                                      c_ulong(len(write_buffer) - 1), byref(written), None)
+        return written.value
 
     def read(self, pipe_id, length_buffer):
         read_buffer = create_string_buffer(length_buffer)

--- a/winusbpy/winusbpy.py
+++ b/winusbpy/winusbpy.py
@@ -212,10 +212,14 @@ class WinUsbPy(object):
 
     def read(self, pipe_id, length_buffer):
         read_buffer = create_string_buffer(length_buffer)
-        result = self.api.exec_function_winusb(WinUsb_ReadPipe, self.handle_winusb, c_ubyte(pipe_id), read_buffer,
-                                               c_ulong(length_buffer), byref(c_ulong(0)), None)
+        read = c_ulong(0)
+        result = self.api.exec_function_winusb(WinUsb_ReadPipe, self.handle_winusb[self._index], c_ubyte(pipe_id),
+                                               read_buffer, c_ulong(length_buffer), byref(read), None)
         if result != 0:
-            return read_buffer
+            if read.value != length_buffer:
+                return read_buffer[:read.value]
+            else:
+                return read_buffer
         else:
             return None
 

--- a/winusbpy/winusbutils.py
+++ b/winusbpy/winusbutils.py
@@ -7,8 +7,10 @@ WinUsb_Initialize = "WinUsb_Initialize"
 WinUsb_ControlTransfer = "WinUsb_ControlTransfer"
 WinUsb_GetDescriptor = "WinUsb_GetDescriptor"
 WinUsb_GetOverlappedResult = "WinUsb_GetOverlappedResult"
+WinUsb_SetPipePolicy = "WinUsb_SetPipePolicy"
 WinUsb_ReadPipe = "WinUsb_ReadPipe"
 WinUsb_WritePipe = "WinUsb_WritePipe"
+WinUsb_FlushPipe = "WinUsb_FlushPipe"
 WinUsb_Free = "WinUsb_Free"
 WinUsb_QueryDeviceInformation = "WinUsb_QueryDeviceInformation"
 WinUsb_QueryInterfaceSettings = "WinUsb_QueryInterfaceSettings"
@@ -68,10 +70,20 @@ def get_winusb_functions(windll):
     # winusb_restypes[WinUsb_ReadPipe] = BOOL
     # winusb_argtypes[WinUsb_ReadPipe] = [c_void_p, c_ubyte, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped]
 
+    # BOOL __stdcall WinUsb_ReadPipe( _In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR PipeID,_Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_ PULONG LengthTransferred,_In_opt_ LPOVERLAPPED Overlapped);
+    winusb_functions[WinUsb_SetPipePolicy] = windll.WinUsb_SetPipePolicy
+    winusb_restypes[WinUsb_SetPipePolicy] = BOOL
+    winusb_argtypes[WinUsb_SetPipePolicy] = [c_void_p, c_ubyte, c_ulong, c_ulong, c_void_p]
+
     # BOOL __stdcall WinUsb_WritePipe(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR PipeID,_In_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_  PULONG LengthTransferred,_In_opt_ LPOVERLAPPED Overlapped);
     winusb_functions[WinUsb_WritePipe] = windll.WinUsb_WritePipe
     # winusb_restypes[WinUsb_WritePipe] = BOOL
     # winusb_argtypes[WinUsb_WritePipe] = [c_void_p, c_ubyte, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped]
+
+    # BOOL __stdcall WinUsb_FlushPipe(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle);
+    winusb_functions[WinUsb_FlushPipe] = windll.WinUsb_FlushPipe
+    winusb_restypes[WinUsb_FlushPipe] = BOOL
+    winusb_argtypes[WinUsb_FlushPipe] = [c_void_p, c_ubyte]
 
     # BOOL __stdcall WinUsb_Free(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle);
     winusb_functions[WinUsb_Free] = windll.WinUsb_Free

--- a/winusbpy/winusbutils.py
+++ b/winusbpy/winusbutils.py
@@ -144,7 +144,7 @@ def get_kernel32_functions(kernel32):
     kernel32_dict["argtypes"] = kernel32_argtypes
     return kernel32_dict
 
-    
+
 def get_setupapi_functions(setupapi):
     setupapi_dict = {}
     setupapi_functions = {}
@@ -176,7 +176,7 @@ def get_setupapi_functions(setupapi):
 
 
 def is_device(vid, pid, path):
-    if path.find(vid) != -1 and path.find(pid) != -1:
+    if path.lower().find('vid_%04x' % int(str(vid), 0)) != -1 and path.lower().find('pid_%04x' % int(str(pid), 0)) != -1:
         return True
     else:
         return False

--- a/winusbpy/winusbutils.py
+++ b/winusbpy/winusbutils.py
@@ -1,6 +1,7 @@
-from ctypes	import *
+from ctypes import *
 from ctypes.wintypes import *
-from winusbclasses import UsbSetupPacket,Overlapped, UsbInterfaceDescriptor, LpSecurityAttributes, GUID, SpDevinfoData, SpDeviceInterfaceData, SpDeviceInterfaceDetailData, PipeInfo
+from .winusbclasses import UsbSetupPacket, Overlapped, UsbInterfaceDescriptor, LpSecurityAttributes, GUID, \
+    SpDevinfoData, SpDeviceInterfaceData, SpDeviceInterfaceDetailData, PipeInfo
 
 WinUsb_Initialize = "WinUsb_Initialize"
 WinUsb_ControlTransfer = "WinUsb_ControlTransfer"
@@ -13,164 +14,169 @@ WinUsb_QueryDeviceInformation = "WinUsb_QueryDeviceInformation"
 WinUsb_QueryInterfaceSettings = "WinUsb_QueryInterfaceSettings"
 WinUsb_GetAssociatedInterface = "WinUsb_GetAssociatedInterface"
 WinUsb_QueryPipe = "WinUsb_QueryPipe"
-WinUsb_ControlTransfer = "WinUsb_ControlTransfer"
-WinUsb_QueryPipe = "WinUsb_QueryPipe"
+# WinUsb_ControlTransfer = "WinUsb_ControlTransfer"
+# WinUsb_QueryPipe = "WinUsb_QueryPipe"
 Close_Handle = "CloseHandle"
 CreateFile = "CreateFileW"
 ReadFile = "ReadFile"
-CancelIo  = "CancelIo"
+CancelIo = "CancelIo"
 WriteFile = "WriteFile"
-SetEvent  = "SetEvent"
+SetEvent = "SetEvent"
 WaitForSingleObject = "WaitForSingleObject"
 GetLastError = "GetLastError"
-SetupDiGetClassDevs  = "SetupDiGetClassDevs"
+SetupDiGetClassDevs = "SetupDiGetClassDevs"
 SetupDiEnumDeviceInterfaces = "SetupDiEnumDeviceInterfaces"
 SetupDiGetDeviceInterfaceDetail = "SetupDiGetDeviceInterfaceDetail"
 
 
 def get_winusb_functions(windll):
-	""" Functions availabe from WinUsb dll and their types"""
-	winusb_dict = {}
-	winusb_functions = {}
-	winusb_restypes = {}
-	winusb_argtypes = {}
+    """ Functions availabe from WinUsb dll and their types"""
+    winusb_dict = {}
+    winusb_functions = {}
+    winusb_restypes = {}
+    winusb_argtypes = {}
 
-	# BOOL __stdcall WinUsb_Initialize( _In_ HANDLE DeviceHandle,_Out_  PWINUSB_INTERFACE_HANDLE InterfaceHandle);
-	winusb_functions[WinUsb_Initialize] = windll.WinUsb_Initialize
-	winusb_restypes[WinUsb_Initialize] = BOOL
-	winusb_argtypes[WinUsb_Initialize] = [HANDLE, POINTER(c_void_p)]
+    # BOOL __stdcall WinUsb_Initialize( _In_ HANDLE DeviceHandle,_Out_  PWINUSB_INTERFACE_HANDLE InterfaceHandle);
+    winusb_functions[WinUsb_Initialize] = windll.WinUsb_Initialize
+    winusb_restypes[WinUsb_Initialize] = BOOL
+    winusb_argtypes[WinUsb_Initialize] = [HANDLE, POINTER(c_void_p)]
 
-	#BOOL __stdcall WinUsb_ControlTransfer(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ WINUSB_SETUP_PACKET SetupPacket, _Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_  PULONG LengthTransferred,_In_opt_  LPOVERLAPPED Overlapped);
-	winusb_functions[WinUsb_ControlTransfer] = windll.WinUsb_ControlTransfer
-	#winusb_restypes[WinUsb_ControlTransfer] = BOOL
-	#winusb_argtypes[WinUsb_ControlTransfer] = [c_void_p, UsbSetupPacket, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped] 
+    # BOOL __stdcall WinUsb_ControlTransfer(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ WINUSB_SETUP_PACKET SetupPacket, _Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_  PULONG LengthTransferred,_In_opt_  LPOVERLAPPED Overlapped);
+    winusb_functions[WinUsb_ControlTransfer] = windll.WinUsb_ControlTransfer
+    # winusb_restypes[WinUsb_ControlTransfer] = BOOL
+    # winusb_argtypes[WinUsb_ControlTransfer] = [c_void_p, UsbSetupPacket, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped] 
 
-	#BOOL __stdcall WinUsb_GetDescriptor(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR DescriptorType,_In_ UCHAR Index,_In_ USHORT LanguageID,_Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_ PULONG LengthTransferred);
-	winusb_functions[WinUsb_GetDescriptor] = windll.WinUsb_GetDescriptor
-	winusb_restypes[WinUsb_GetDescriptor] = BOOL
-	winusb_argtypes[WinUsb_GetDescriptor] = [c_void_p, c_ubyte, c_ubyte, c_ushort, POINTER(c_ubyte), c_ulong, POINTER(c_ulong)]
+    # BOOL __stdcall WinUsb_GetDescriptor(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR DescriptorType,_In_ UCHAR Index,_In_ USHORT LanguageID,_Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_ PULONG LengthTransferred);
+    winusb_functions[WinUsb_GetDescriptor] = windll.WinUsb_GetDescriptor
+    winusb_restypes[WinUsb_GetDescriptor] = BOOL
+    winusb_argtypes[WinUsb_GetDescriptor] = [c_void_p, c_ubyte, c_ubyte, c_ushort, POINTER(c_ubyte), c_ulong, POINTER(c_ulong)]
 
-        #BOOL __stdcall WinUsb_GetOverlappedResult(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ LPOVERLAPPED lpOverlapped,_Out_ LPDWORD lpNumberOfBytesTransferred,_In_ BOOL bWait);
-	winusb_functions[WinUsb_GetOverlappedResult] = windll.WinUsb_GetOverlappedResult
-	winusb_restypes[WinUsb_GetOverlappedResult] = BOOL
-	#winusb_argtypes[WinUsb_GetOverlappedResult] = []
-        
-	#BOOL __stdcall WinUsb_ReadPipe( _In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR PipeID,_Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_ PULONG LengthTransferred,_In_opt_ LPOVERLAPPED Overlapped);
-	winusb_functions[WinUsb_ReadPipe] = windll.WinUsb_ReadPipe
-	#winusb_restypes[WinUsb_ReadPipe] = BOOL
-	#winusb_argtypes[WinUsb_ReadPipe] = [c_void_p, c_ubyte, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped]
+    # BOOL __stdcall WinUsb_GetOverlappedResult(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ LPOVERLAPPED lpOverlapped,_Out_ LPDWORD lpNumberOfBytesTransferred,_In_ BOOL bWait);
+    winusb_functions[WinUsb_GetOverlappedResult] = windll.WinUsb_GetOverlappedResult
+    winusb_restypes[WinUsb_GetOverlappedResult] = BOOL
+    # winusb_argtypes[WinUsb_GetOverlappedResult] = []
 
-	#BOOL __stdcall WinUsb_WritePipe(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR PipeID,_In_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_  PULONG LengthTransferred,_In_opt_ LPOVERLAPPED Overlapped);
-	winusb_functions[WinUsb_WritePipe] = windll.WinUsb_WritePipe
-	#winusb_restypes[WinUsb_WritePipe] = BOOL
-	#winusb_argtypes[WinUsb_WritePipe] = [c_void_p, c_ubyte, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped]
+    # BOOL __stdcall WinUsb_ReadPipe( _In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR PipeID,_Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_ PULONG LengthTransferred,_In_opt_ LPOVERLAPPED Overlapped);
+    winusb_functions[WinUsb_ReadPipe] = windll.WinUsb_ReadPipe
+    # winusb_restypes[WinUsb_ReadPipe] = BOOL
+    # winusb_argtypes[WinUsb_ReadPipe] = [c_void_p, c_ubyte, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped]
 
-	#BOOL __stdcall WinUsb_Free(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle);
-	winusb_functions[WinUsb_Free] = windll.WinUsb_Free
-	winusb_restypes[WinUsb_Free] = BOOL
-	winusb_argtypes[WinUsb_Free] = [c_void_p]
+    # BOOL __stdcall WinUsb_WritePipe(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR PipeID,_In_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_  PULONG LengthTransferred,_In_opt_ LPOVERLAPPED Overlapped);
+    winusb_functions[WinUsb_WritePipe] = windll.WinUsb_WritePipe
+    # winusb_restypes[WinUsb_WritePipe] = BOOL
+    # winusb_argtypes[WinUsb_WritePipe] = [c_void_p, c_ubyte, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped]
 
-	#BOOL __stdcall WinUsb_QueryDeviceInformation(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ ULONG InformationType,_Inout_ PULONG BufferLength,_Out_ PVOID Buffer);
-	winusb_functions[WinUsb_QueryDeviceInformation] = windll.WinUsb_QueryDeviceInformation
-	winusb_restypes[WinUsb_QueryDeviceInformation] = BOOL
-	winusb_argtypes[WinUsb_QueryDeviceInformation] = [c_void_p, c_ulong, POINTER(c_ulong), c_void_p]
+    # BOOL __stdcall WinUsb_Free(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle);
+    winusb_functions[WinUsb_Free] = windll.WinUsb_Free
+    winusb_restypes[WinUsb_Free] = BOOL
+    winusb_argtypes[WinUsb_Free] = [c_void_p]
 
-	#BOOL __stdcall WinUsb_QueryInterfaceSettings(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR AlternateSettingNumber,_Out_ PUSB_INTERFACE_DESCRIPTOR UsbAltInterfaceDescriptor);
-	winusb_functions[WinUsb_QueryInterfaceSettings] = windll.WinUsb_QueryInterfaceSettings
-	winusb_restypes[WinUsb_QueryInterfaceSettings] = BOOL
-	winusb_argtypes[WinUsb_QueryInterfaceSettings] = [c_void_p, c_ubyte, POINTER(UsbInterfaceDescriptor)]
+    # BOOL __stdcall WinUsb_QueryDeviceInformation(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ ULONG InformationType,_Inout_ PULONG BufferLength,_Out_ PVOID Buffer);
+    winusb_functions[WinUsb_QueryDeviceInformation] = windll.WinUsb_QueryDeviceInformation
+    winusb_restypes[WinUsb_QueryDeviceInformation] = BOOL
+    winusb_argtypes[WinUsb_QueryDeviceInformation] = [c_void_p, c_ulong, POINTER(c_ulong), c_void_p]
 
-	winusb_functions[WinUsb_QueryPipe] = windll.WinUsb_QueryPipe
-	winusb_restypes[WinUsb_QueryPipe] = BOOL
-	winusb_argtypes[WinUsb_QueryPipe] = [c_void_p, c_ubyte, c_ubyte, POINTER(PipeInfo)]
+    # BOOL __stdcall WinUsb_QueryInterfaceSettings(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR AlternateSettingNumber,_Out_ PUSB_INTERFACE_DESCRIPTOR UsbAltInterfaceDescriptor);
+    winusb_functions[WinUsb_QueryInterfaceSettings] = windll.WinUsb_QueryInterfaceSettings
+    winusb_restypes[WinUsb_QueryInterfaceSettings] = BOOL
+    winusb_argtypes[WinUsb_QueryInterfaceSettings] = [c_void_p, c_ubyte, POINTER(UsbInterfaceDescriptor)]
 
-	winusb_functions[WinUsb_GetAssociatedInterface] = windll.WinUsb_GetAssociatedInterface
-	winusb_restypes[WinUsb_GetAssociatedInterface] = BOOL
-	winusb_argtypes[WinUsb_GetAssociatedInterface] = [c_void_p, c_ubyte, POINTER(c_void_p)]
+    winusb_functions[WinUsb_QueryPipe] = windll.WinUsb_QueryPipe
+    winusb_restypes[WinUsb_QueryPipe] = BOOL
+    winusb_argtypes[WinUsb_QueryPipe] = [c_void_p, c_ubyte, c_ubyte, POINTER(PipeInfo)]
 
-	winusb_dict["functions"] = winusb_functions 
-	winusb_dict["restypes"] = winusb_restypes
-	winusb_dict["argtypes"] = winusb_argtypes
-	return winusb_dict
+    winusb_functions[WinUsb_GetAssociatedInterface] = windll.WinUsb_GetAssociatedInterface
+    winusb_restypes[WinUsb_GetAssociatedInterface] = BOOL
+    winusb_argtypes[WinUsb_GetAssociatedInterface] = [c_void_p, c_ubyte, POINTER(c_void_p)]
 
+    winusb_dict["functions"] = winusb_functions 
+    winusb_dict["restypes"] = winusb_restypes
+    winusb_dict["argtypes"] = winusb_argtypes
+    return winusb_dict
+
+    
 def get_kernel32_functions(kernel32):
-	kernel32_dict = {}
-	kernel32_functions = {}
-	kernel32_restypes = {}
-	kernel32_argtypes = {}
+    kernel32_dict = {}
+    kernel32_functions = {}
+    kernel32_restypes = {}
+    kernel32_argtypes = {}
 
-	#BOOL WINAPI CloseHandle(_In_  HANDLE hObject);
-	kernel32_functions[Close_Handle] = kernel32.CloseHandle
-	kernel32_restypes[Close_Handle] = BOOL
-	kernel32_argtypes[Close_Handle] = [HANDLE]
+    # BOOL WINAPI CloseHandle(_In_  HANDLE hObject);
+    kernel32_functions[Close_Handle] = kernel32.CloseHandle
+    kernel32_restypes[Close_Handle] = BOOL
+    kernel32_argtypes[Close_Handle] = [HANDLE]
 
-	#BOOL WINAPI ReadFile(_In_ HANDLE hFile,_Out_ LPVOID lpBuffer,_In_ DWORD nNumberOfBytesToRead,_Out_opt_ LPDWORD lpNumberOfBytesRead,_Inout_opt_ LPOVERLAPPED lpOverlapped);
-	kernel32_functions[ReadFile] = kernel32.ReadFile
-	kernel32_restypes[ReadFile] = BOOL
-	kernel32_argtypes[ReadFile] = [HANDLE, c_void_p, DWORD, POINTER(DWORD), POINTER(Overlapped)]
+    # BOOL WINAPI ReadFile(_In_ HANDLE hFile,_Out_ LPVOID lpBuffer,_In_ DWORD nNumberOfBytesToRead,_Out_opt_ LPDWORD lpNumberOfBytesRead,_Inout_opt_ LPOVERLAPPED lpOverlapped);
+    kernel32_functions[ReadFile] = kernel32.ReadFile
+    kernel32_restypes[ReadFile] = BOOL
+    kernel32_argtypes[ReadFile] = [HANDLE, c_void_p, DWORD, POINTER(DWORD), POINTER(Overlapped)]
 
-	#BOOL WINAPI CancelIo(_In_  HANDLE hFile);
-	kernel32_functions[CancelIo] = kernel32.CancelIo
-	kernel32_restypes[CancelIo] = BOOL
-	kernel32_argtypes[CancelIo] = [HANDLE]
+    # BOOL WINAPI CancelIo(_In_  HANDLE hFile);
+    kernel32_functions[CancelIo] = kernel32.CancelIo
+    kernel32_restypes[CancelIo] = BOOL
+    kernel32_argtypes[CancelIo] = [HANDLE]
 
-	#BOOL WINAPI WriteFile(_In_ HANDLE hFile,_In_ LPCVOID lpBuffer,_In_ DWORD nNumberOfBytesToWrite,_Out_opt_ LPDWORD lpNumberOfBytesWritten,_Inout_opt_  LPOVERLAPPED lpOverlapped);
-	kernel32_functions[WriteFile] = kernel32.WriteFile
-	kernel32_restypes[WriteFile] = BOOL
-	kernel32_argtypes[WriteFile] = [HANDLE, c_void_p, DWORD, POINTER(DWORD), POINTER(Overlapped)]
+    # BOOL WINAPI WriteFile(_In_ HANDLE hFile,_In_ LPCVOID lpBuffer,_In_ DWORD nNumberOfBytesToWrite,_Out_opt_ LPDWORD lpNumberOfBytesWritten,_Inout_opt_  LPOVERLAPPED lpOverlapped);
+    kernel32_functions[WriteFile] = kernel32.WriteFile
+    kernel32_restypes[WriteFile] = BOOL
+    kernel32_argtypes[WriteFile] = [HANDLE, c_void_p, DWORD, POINTER(DWORD), POINTER(Overlapped)]
 
-	#BOOL WINAPI SetEvent(_In_ HANDLE hEvent);
-	kernel32_functions[SetEvent] = kernel32.SetEvent
-	kernel32_restypes[SetEvent] = BOOL
-	kernel32_argtypes[SetEvent] = [HANDLE]
+    # BOOL WINAPI SetEvent(_In_ HANDLE hEvent);
+    kernel32_functions[SetEvent] = kernel32.SetEvent
+    kernel32_restypes[SetEvent] = BOOL
+    kernel32_argtypes[SetEvent] = [HANDLE]
 
-	#DWORD WINAPI WaitForSingleObject(_In_ HANDLE hHandle, _In_  DWORD dwMilliseconds);
-	kernel32_functions[WaitForSingleObject] = kernel32.WaitForSingleObject
-	kernel32_restypes[WaitForSingleObject] = DWORD
-	kernel32_argtypes[WaitForSingleObject] = [HANDLE, DWORD]
+    # DWORD WINAPI WaitForSingleObject(_In_ HANDLE hHandle, _In_  DWORD dwMilliseconds);
+    kernel32_functions[WaitForSingleObject] = kernel32.WaitForSingleObject
+    kernel32_restypes[WaitForSingleObject] = DWORD
+    kernel32_argtypes[WaitForSingleObject] = [HANDLE, DWORD]
 
-	#HANDLE WINAPI CreateFile(_In_ LPCTSTR lpFileName,_In_ DWORD dwDesiredAccess,_In_ DWORD dwShareMode,_In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes,_In_ DWORD dwCreationDisposition,_In_ DWORD dwFlagsAndAttributes,_In_opt_ HANDLE hTemplateFile);
-	kernel32_functions[CreateFile] = kernel32.CreateFileW 
+    # HANDLE WINAPI CreateFile(_In_ LPCTSTR lpFileName,_In_ DWORD dwDesiredAccess,_In_ DWORD dwShareMode,_In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes,_In_ DWORD dwCreationDisposition,_In_ DWORD dwFlagsAndAttributes,_In_opt_ HANDLE hTemplateFile);
+    kernel32_functions[CreateFile] = kernel32.CreateFileW 
 
-	#DWORD WINAPI GetLastError(void)
-	kernel32_functions[GetLastError] = kernel32.GetLastError
-	kernel32_restypes[GetLastError] = DWORD
-	kernel32_argtypes[GetLastError] = []
+    # DWORD WINAPI GetLastError(void)
+    kernel32_functions[GetLastError] = kernel32.GetLastError
+    kernel32_restypes[GetLastError] = DWORD
+    kernel32_argtypes[GetLastError] = []
 
-	kernel32_dict["functions"] = kernel32_functions
-	kernel32_dict["restypes"] = kernel32_restypes
-	kernel32_dict["argtypes"] = kernel32_argtypes
-	return kernel32_dict
+    kernel32_dict["functions"] = kernel32_functions
+    kernel32_dict["restypes"] = kernel32_restypes
+    kernel32_dict["argtypes"] = kernel32_argtypes
+    return kernel32_dict
 
+    
 def get_setupapi_functions(setupapi):
-	setupapi_dict = {}
-	setupapi_functions = {}
-	setupapi_restypes = {}
-	setupapi_argtypes = {}
+    setupapi_dict = {}
+    setupapi_functions = {}
+    setupapi_restypes = {}
+    setupapi_argtypes = {}
 
-	#HDEVINFO SetupDiGetClassDevs(_In_opt_ const GUID *ClassGuid,_In_opt_ PCTSTR Enumerator,_In_opt_ HWND hwndParent,_In_ DWORD Flags);
-	setupapi_functions[SetupDiGetClassDevs] = setupapi.SetupDiGetClassDevsW
-	setupapi_restypes[SetupDiGetClassDevs] = HANDLE
-	setupapi_argtypes[SetupDiGetClassDevs] = [POINTER(GUID), c_wchar_p, HANDLE, DWORD]
+    # HDEVINFO SetupDiGetClassDevs(_In_opt_ const GUID *ClassGuid,_In_opt_ PCTSTR Enumerator,_In_opt_ HWND hwndParent,_In_ DWORD Flags);
+    setupapi_functions[SetupDiGetClassDevs] = setupapi.SetupDiGetClassDevsW
+    setupapi_restypes[SetupDiGetClassDevs] = HANDLE
+    setupapi_argtypes[SetupDiGetClassDevs] = [POINTER(GUID), c_wchar_p, HANDLE, DWORD]
 
-	#BOOL SetupDiEnumDeviceInterfaces(_In_ HDEVINFO DeviceInfoSet,_In_opt_ PSP_DEVINFO_DATA DeviceInfoData,_In_ const GUID *InterfaceClassGuid,_In_ DWORD MemberIndex,_Out_ PSP_DEVICE_INTERFACE_DATA DeviceInterfaceData);
-	setupapi_functions[SetupDiEnumDeviceInterfaces] = setupapi.SetupDiEnumDeviceInterfaces
-	setupapi_restypes[SetupDiEnumDeviceInterfaces] = BOOL
-	setupapi_argtypes[SetupDiEnumDeviceInterfaces] = [c_void_p, POINTER(SpDevinfoData), POINTER(GUID), DWORD, POINTER(SpDeviceInterfaceData)]
+    # BOOL SetupDiEnumDeviceInterfaces(_In_ HDEVINFO DeviceInfoSet,_In_opt_ PSP_DEVINFO_DATA DeviceInfoData,_In_ const GUID *InterfaceClassGuid,_In_ DWORD MemberIndex,_Out_ PSP_DEVICE_INTERFACE_DATA DeviceInterfaceData);
+    setupapi_functions[SetupDiEnumDeviceInterfaces] = setupapi.SetupDiEnumDeviceInterfaces
+    setupapi_restypes[SetupDiEnumDeviceInterfaces] = BOOL
+    setupapi_argtypes[SetupDiEnumDeviceInterfaces] = [c_void_p, POINTER(SpDevinfoData), POINTER(GUID), DWORD,
+                                                      POINTER(SpDeviceInterfaceData)]
 
-	#BOOL SetupDiGetDeviceInterfaceDetail(_In_ HDEVINFO DeviceInfoSet,_In_ PSP_DEVICE_INTERFACE_DATA DeviceInterfaceData,_Out_opt_ PSP_DEVICE_INTERFACE_DETAIL_DATA DeviceInterfaceDetailData,_In_ DWORD DeviceInterfaceDetailDataSize,_Out_opt_  PDWORD RequiredSize,_Out_opt_  PSP_DEVINFO_DATA DeviceInfoData);
-	setupapi_functions[SetupDiGetDeviceInterfaceDetail] = setupapi.SetupDiGetDeviceInterfaceDetailW
-	setupapi_restypes[SetupDiGetDeviceInterfaceDetail] = BOOL
-	setupapi_argtypes[SetupDiGetDeviceInterfaceDetail] = [c_void_p, POINTER(SpDeviceInterfaceData), POINTER(SpDeviceInterfaceDetailData), DWORD, POINTER(DWORD), POINTER(SpDevinfoData)]
+    # BOOL SetupDiGetDeviceInterfaceDetail(_In_ HDEVINFO DeviceInfoSet,_In_ PSP_DEVICE_INTERFACE_DATA DeviceInterfaceData,_Out_opt_ PSP_DEVICE_INTERFACE_DETAIL_DATA DeviceInterfaceDetailData,_In_ DWORD DeviceInterfaceDetailDataSize,_Out_opt_  PDWORD RequiredSize,_Out_opt_  PSP_DEVINFO_DATA DeviceInfoData);
+    setupapi_functions[SetupDiGetDeviceInterfaceDetail] = setupapi.SetupDiGetDeviceInterfaceDetailW
+    setupapi_restypes[SetupDiGetDeviceInterfaceDetail] = BOOL
+    setupapi_argtypes[SetupDiGetDeviceInterfaceDetail] = [c_void_p, POINTER(SpDeviceInterfaceData),
+                                                          POINTER(SpDeviceInterfaceDetailData), DWORD, POINTER(DWORD),
+                                                          POINTER(SpDevinfoData)]
 
-	setupapi_dict["functions"] = setupapi_functions
-	setupapi_dict["restypes"] = setupapi_restypes
-	setupapi_dict["argtypes"] = setupapi_argtypes 
-	return setupapi_dict
+    setupapi_dict["functions"] = setupapi_functions
+    setupapi_dict["restypes"] = setupapi_restypes
+    setupapi_dict["argtypes"] = setupapi_argtypes
+    return setupapi_dict
+
 
 def is_device(vid, pid, path):
-	if path.find(vid) != -1 and path.find(pid) != -1:
-		return True
-	else:
-		return False
-
+    if path.find(vid) != -1 and path.find(pid) != -1:
+        return True
+    else:
+        return False

--- a/winusbpy/winusbutils.py
+++ b/winusbpy/winusbutils.py
@@ -27,7 +27,13 @@ GetLastError = "GetLastError"
 SetupDiGetClassDevs = "SetupDiGetClassDevs"
 SetupDiEnumDeviceInterfaces = "SetupDiEnumDeviceInterfaces"
 SetupDiGetDeviceInterfaceDetail = "SetupDiGetDeviceInterfaceDetail"
+SetupDiGetDeviceRegistryProperty = "SetupDiGetDeviceRegistryProperty"
 SetupDiEnumDeviceInfo = "SetupDiEnumDeviceInfo"
+
+SPDRP_HARDWAREID = 1
+SPDRP_FRIENDLYNAME = 12
+SPDRP_LOCATION_PATHS = 35
+SPDRP_MFG = 11
 
 
 def get_winusb_functions(windll):
@@ -171,6 +177,14 @@ def get_setupapi_functions(setupapi):
                                                           POINTER(SpDeviceInterfaceDetailData), DWORD, POINTER(DWORD),
                                                           POINTER(SpDevinfoData)]
 
+    # BOOL SetupDiGetDeviceInterfaceDetail(_In_ HDEVINFO DeviceInfoSet,_In_ PSP_DEVICE_INTERFACE_DATA DeviceInterfaceData,_Out_opt_ PSP_DEVICE_INTERFACE_DETAIL_DATA DeviceInterfaceDetailData,_In_ DWORD DeviceInterfaceDetailDataSize,_Out_opt_  PDWORD RequiredSize,_Out_opt_  PSP_DEVINFO_DATA DeviceInfoData);
+    setupapi_functions[SetupDiGetDeviceRegistryProperty] = setupapi.SetupDiGetDeviceRegistryPropertyW
+    setupapi_restypes[SetupDiGetDeviceRegistryProperty] = BOOL
+    setupapi_argtypes[SetupDiGetDeviceRegistryProperty] = [c_void_p, POINTER(SpDevinfoData),
+                                                          DWORD, POINTER(DWORD),
+                                                          c_void_p, DWORD, POINTER(DWORD)]
+    # [HDEVINFO, PSP_DEVINFO_DATA, DWORD, PDWORD, PBYTE, DWORD, PDWORD]
+
     # BOOL SetupDiEnumDeviceInfo(HDEVINFO DeviceInfoSet, DWORD MemberIndex, PSP_DEVINFO_DATA DeviceInfoData);
     setupapi_functions[SetupDiEnumDeviceInfo] = setupapi.SetupDiEnumDeviceInfo
     setupapi_restypes[SetupDiEnumDeviceInfo] = BOOL
@@ -182,8 +196,11 @@ def get_setupapi_functions(setupapi):
     return setupapi_dict
 
 
-def is_device(vid, pid, path):
-    if path.lower().find('vid_%04x' % int(str(vid), 0)) != -1 and path.lower().find('pid_%04x' % int(str(pid), 0)) != -1:
+def is_device(vid, pid, path, name=None):
+    if name and name.lower() == path.lower():
         return True
+    if vid and pid:
+        if path.lower().find('vid_%04x' % int(str(vid), 0)) != -1 and path.lower().find('pid_%04x' % int(str(pid), 0)) != -1:
+            return True
     else:
         return False

--- a/winusbpy/winusbutils.py
+++ b/winusbpy/winusbutils.py
@@ -27,6 +27,7 @@ GetLastError = "GetLastError"
 SetupDiGetClassDevs = "SetupDiGetClassDevs"
 SetupDiEnumDeviceInterfaces = "SetupDiEnumDeviceInterfaces"
 SetupDiGetDeviceInterfaceDetail = "SetupDiGetDeviceInterfaceDetail"
+SetupDiEnumDeviceInfo = "SetupDiEnumDeviceInfo"
 
 
 def get_winusb_functions(windll):
@@ -132,7 +133,8 @@ def get_kernel32_functions(kernel32):
     kernel32_argtypes[WaitForSingleObject] = [HANDLE, DWORD]
 
     # HANDLE WINAPI CreateFile(_In_ LPCTSTR lpFileName,_In_ DWORD dwDesiredAccess,_In_ DWORD dwShareMode,_In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes,_In_ DWORD dwCreationDisposition,_In_ DWORD dwFlagsAndAttributes,_In_opt_ HANDLE hTemplateFile);
-    kernel32_functions[CreateFile] = kernel32.CreateFileW 
+    kernel32_functions[CreateFile] = kernel32.CreateFileW
+    kernel32_restypes[CreateFile] = HANDLE
 
     # DWORD WINAPI GetLastError(void)
     kernel32_functions[GetLastError] = kernel32.GetLastError
@@ -168,6 +170,11 @@ def get_setupapi_functions(setupapi):
     setupapi_argtypes[SetupDiGetDeviceInterfaceDetail] = [c_void_p, POINTER(SpDeviceInterfaceData),
                                                           POINTER(SpDeviceInterfaceDetailData), DWORD, POINTER(DWORD),
                                                           POINTER(SpDevinfoData)]
+
+    # BOOL SetupDiEnumDeviceInfo(HDEVINFO DeviceInfoSet, DWORD MemberIndex, PSP_DEVINFO_DATA DeviceInfoData);
+    setupapi_functions[SetupDiEnumDeviceInfo] = setupapi.SetupDiEnumDeviceInfo
+    setupapi_restypes[SetupDiEnumDeviceInfo] = BOOL
+    setupapi_argtypes[SetupDiEnumDeviceInfo] = [c_void_p, DWORD, POINTER(SpDevinfoData)]
 
     setupapi_dict["functions"] = setupapi_functions
     setupapi_dict["restypes"] = setupapi_restypes


### PR DESCRIPTION
This PR contains a number of patches made during my work on WinUsbCDC as discussed in https://github.com/felHR85/WinUsbPy/issues/6#issuecomment-647360544

Includes Python 3 support originally based on:
https://github.com/Vlastbia/WinUsbPy/commit/05bfac7b0cd9fafdbb1c8d2ee2856b0460631d00

On top of this there's 64bit support (over a couple of commits), changes to the way WinUSB devices are found/attached to to support optionally searching by name instead on vid/pid.

There's some work to support communicating with devices that are part of a composite device but I haven't included all of the commits because I think my approach for it was pretty hacky and not ideal.

There's a couple of new functions: `flush` and `set_timeout`

Minor changes to the return values of read() and write() 

