### PR TITLE
High lvl api bugfix: 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+my_test_file.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/winusbpy/winusbutils.py
+++ b/winusbpy/winusbutils.py
@@ -53,7 +53,7 @@ def get_winusb_functions(windll):
     # BOOL __stdcall WinUsb_ControlTransfer(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ WINUSB_SETUP_PACKET SetupPacket, _Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_opt_  PULONG LengthTransferred,_In_opt_  LPOVERLAPPED Overlapped);
     winusb_functions[WinUsb_ControlTransfer] = windll.WinUsb_ControlTransfer
     # winusb_restypes[WinUsb_ControlTransfer] = BOOL
-    # winusb_argtypes[WinUsb_ControlTransfer] = [c_void_p, UsbSetupPacket, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped] 
+    # winusb_argtypes[WinUsb_ControlTransfer] = [c_void_p, UsbSetupPacket, POINTER(c_ubyte), c_ulong, POINTER(c_ulong), LpOverlapped]
 
     # BOOL __stdcall WinUsb_GetDescriptor(_In_ WINUSB_INTERFACE_HANDLE InterfaceHandle,_In_ UCHAR DescriptorType,_In_ UCHAR Index,_In_ USHORT LanguageID,_Out_ PUCHAR Buffer,_In_ ULONG BufferLength,_Out_ PULONG LengthTransferred);
     winusb_functions[WinUsb_GetDescriptor] = windll.WinUsb_GetDescriptor
@@ -108,12 +108,12 @@ def get_winusb_functions(windll):
     winusb_restypes[WinUsb_GetAssociatedInterface] = BOOL
     winusb_argtypes[WinUsb_GetAssociatedInterface] = [c_void_p, c_ubyte, POINTER(c_void_p)]
 
-    winusb_dict["functions"] = winusb_functions 
+    winusb_dict["functions"] = winusb_functions
     winusb_dict["restypes"] = winusb_restypes
     winusb_dict["argtypes"] = winusb_argtypes
     return winusb_dict
 
-    
+
 def get_kernel32_functions(kernel32):
     kernel32_dict = {}
     kernel32_functions = {}
@@ -209,6 +209,10 @@ def get_setupapi_functions(setupapi):
 
 
 def is_device(vid, pid, path, name=None):
+    # this is not working
+    # not used
+    # replaced by extract_device_from_vid_pid
+
     if name and name.lower() == path.lower():
         return True
     if vid and pid:


### PR DESCRIPTION
Hi,

Thanks for this wrapper.

I had initially some issues connecting to my USB device using the high level API.
Especially, **init_winusb_device()**  required a 'name' field, which doesn't make sense IMHO.

Also, some high level API functions (as write, read, etc.) were throwing errors due to indexing the interface handle (**self.handle_winusb[self._index]** ???)

I propose the following changes then, which worked for me (and my device) 

**Platform**:
Windows 10, python 3.8.6 32bit
**USB test device:**
Custom STM32 USB device (CDC data, bulk transfert with 1 IN and 1 OUT endpoint)